### PR TITLE
Fix wave calculation

### DIFF
--- a/NSynth/SawtoothWaveCalculator.cs
+++ b/NSynth/SawtoothWaveCalculator.cs
@@ -1,4 +1,6 @@
-﻿namespace NSynth
+﻿using System;
+
+namespace NSynth
 {
     public sealed class SawtoothWaveCalculator : ComplexWaveCalculator
     {
@@ -13,7 +15,8 @@
 
         protected override float AmplitudeForHarmonic(int harmonic)
         {
-            return 1/(float) harmonic;
+            // multiplying by 2 / pi renormalises the amplitude
+            return (float)((1.0 / harmonic) * (2.0 / Math.PI));
         }
     }
 }

--- a/NSynth/SquareWaveCalculator.cs
+++ b/NSynth/SquareWaveCalculator.cs
@@ -1,4 +1,6 @@
-﻿namespace NSynth
+﻿using System;
+
+namespace NSynth
 {
     public sealed class SquareWaveCalculator : ComplexWaveCalculator
     {
@@ -13,7 +15,8 @@
 
         protected override float AmplitudeForHarmonic(int harmonic)
         {
-            return 1 / (float)harmonic;
+            // multiplying by 4 / pi renormalises the amplitude
+            return (float)((1.0 / harmonic) * (4.0 / Math.PI));
         }
     }
 }

--- a/NSynth/TriangleWaveCalculator.cs
+++ b/NSynth/TriangleWaveCalculator.cs
@@ -16,7 +16,8 @@ namespace NSynth
         protected override float AmplitudeForHarmonic(int harmonic)
         {
             // multiplying by sin(harmonic * pi / 2) inverts every other odd harmonic
-            return (float)((1.0 / (harmonic * harmonic)) * Math.Sin(harmonic * Math.PI / 2));
+            // multiplying by 8 / pi^2 renormalises the amplitude
+            return (float)((1.0 / (harmonic * harmonic)) * Math.Sin(harmonic * Math.PI / 2) * (8.0 / (Math.PI * Math.PI)));
         }
     }
 }

--- a/NSynth/TriangleWaveCalculator.cs
+++ b/NSynth/TriangleWaveCalculator.cs
@@ -1,4 +1,6 @@
-﻿namespace NSynth
+﻿using System;
+
+namespace NSynth
 {
     public sealed class TriangleWaveCalculator : ComplexWaveCalculator
     {
@@ -13,7 +15,8 @@
 
         protected override float AmplitudeForHarmonic(int harmonic)
         {
-            return 1 / (float)(harmonic * harmonic);
+            // multiplying by sin(harmonic * pi / 2) inverts every other odd harmonic
+            return (float)((1.0 / (harmonic * harmonic)) * Math.Sin(harmonic * Math.PI / 2));
         }
     }
 }


### PR DESCRIPTION
Hi,

I Initially noticed that the calculation for the triangle wave wasn't quite correct, every other odd harmonic should be inverted to generate the triangle. Currently the wave being generated is the top wave, the bottom is after correction.

![image](https://cloud.githubusercontent.com/assets/754213/18090636/91162b64-6ebd-11e6-933e-fb000f77f3aa.png)

The second change included is just to re-normalise the calculated amplitude for each harmonic to prevent clipping.
